### PR TITLE
Fix all 69 golangci-lint findings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,6 @@ jobs:
         uses: golangci/golangci-lint-action@v7
         with:
           version: v2.10.1
-          only-new-issues: true
 
   test:
     name: Test (${{ matrix.os }})

--- a/cmd/palaver/hotkey_linux.go
+++ b/cmd/palaver/hotkey_linux.go
@@ -32,7 +32,7 @@ func createListener(cfg *config.Config, dbg *log.Logger) (hotkey.Listener, error
 // initPortAudio suppresses ALSA/JACK noise during PortAudio initialization
 // by temporarily redirecting stderr to /dev/null, then calls portaudio.Initialize().
 func initPortAudio() error {
-	stderrFd := int(os.Stderr.Fd())
+	stderrFd := int(os.Stderr.Fd()) //nolint:gosec // fd fits in int on all supported platforms
 	savedStderr, err := syscall.Dup(stderrFd)
 	if err != nil {
 		// If we can't dup stderr, just initialize without suppression
@@ -40,17 +40,17 @@ func initPortAudio() error {
 	}
 	devNull, err := os.Open(os.DevNull)
 	if err != nil {
-		syscall.Close(savedStderr)
+		_ = syscall.Close(savedStderr)
 		return portaudio.Initialize()
 	}
-	syscall.Dup2(int(devNull.Fd()), stderrFd)
-	devNull.Close()
+	_ = syscall.Dup2(int(devNull.Fd()), stderrFd)
+	_ = devNull.Close()
 
 	initErr := portaudio.Initialize()
 
 	// Restore stderr
-	syscall.Dup2(savedStderr, stderrFd)
-	syscall.Close(savedStderr)
+	_ = syscall.Dup2(savedStderr, stderrFd)
+	_ = syscall.Close(savedStderr)
 
 	return initErr
 }

--- a/cmd/palaver/main.go
+++ b/cmd/palaver/main.go
@@ -76,7 +76,7 @@ func runSetup(cfg *config.Config, dbg *log.Logger) {
 			os.Exit(1)
 		}
 		fmt.Println("Server is healthy!")
-		srv.Stop()
+		_ = srv.Stop()
 		cancel()
 	}
 
@@ -113,7 +113,7 @@ func run() {
 	if err := initPortAudio(); err != nil {
 		log.Fatalf("portaudio init: %v", err)
 	}
-	defer portaudio.Terminate()
+	defer func() { _ = portaudio.Terminate() }()
 
 	dbg.Printf("portaudio initialized")
 
@@ -126,7 +126,7 @@ func run() {
 	// Warn if sending audio over plaintext HTTP to a non-local host
 	if u, err := url.Parse(cfg.Transcription.BaseURL); err == nil {
 		if u.Scheme == "http" && u.Hostname() != "localhost" && u.Hostname() != "127.0.0.1" && u.Hostname() != "::1" {
-			log.Printf("WARNING: transcription base_url uses plaintext HTTP to non-local host %q — audio data will be sent unencrypted", u.Hostname())
+			log.Printf("WARNING: transcription base_url uses plaintext HTTP to non-local host %q — audio data will be sent unencrypted", u.Hostname()) //nolint:gosec // log message from trusted config value
 		}
 	}
 
@@ -222,6 +222,6 @@ func run() {
 	cancel()
 	serverCancel()
 	if srv != nil {
-		srv.Stop()
+		_ = srv.Stop()
 	}
 }

--- a/internal/chime/chime.go
+++ b/internal/chime/chime.go
@@ -41,7 +41,7 @@ func New(startPath, stopPath string, enabled bool, logger *log.Logger) (*Player,
 	}
 
 	if startPath != "" {
-		data, err := os.ReadFile(startPath)
+		data, err := os.ReadFile(startPath) //nolint:gosec // path from user config
 		if err != nil {
 			return nil, fmt.Errorf("read start chime %s: %w", startPath, err)
 		}
@@ -49,7 +49,7 @@ func New(startPath, stopPath string, enabled bool, logger *log.Logger) (*Player,
 	}
 
 	if stopPath != "" {
-		data, err := os.ReadFile(stopPath)
+		data, err := os.ReadFile(stopPath) //nolint:gosec // path from user config
 		if err != nil {
 			return nil, fmt.Errorf("read stop chime %s: %w", stopPath, err)
 		}
@@ -79,7 +79,7 @@ func (p *Player) play(data []byte) {
 			}
 			return
 		}
-		defer streamer.Close()
+		defer func() { _ = streamer.Close() }()
 
 		p.initSpeaker(format)
 		if p.initErr != nil {

--- a/internal/chime/chime_test.go
+++ b/internal/chime/chime_test.go
@@ -41,8 +41,12 @@ func TestNewWithCustomPaths(t *testing.T) {
 	stopPath := filepath.Join(dir, "custom_stop.wav")
 
 	// Write the embedded defaults as custom files for testing
-	os.WriteFile(startPath, defaultStartWav, 0644)
-	os.WriteFile(stopPath, defaultStopWav, 0644)
+	if err := os.WriteFile(startPath, defaultStartWav, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(stopPath, defaultStopWav, 0o644); err != nil {
+		t.Fatal(err)
+	}
 
 	p, err := New(startPath, stopPath, true, nil)
 	if err != nil {

--- a/internal/clipboard/clipboard_linux.go
+++ b/internal/clipboard/clipboard_linux.go
@@ -68,7 +68,7 @@ func typeWaylandDirect(text string) error {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	cmd := exec.CommandContext(ctx, "ydotool", "type", "--delay", "0", "--", text)
+	cmd := exec.CommandContext(ctx, "ydotool", "type", "--delay", "0", "--", text) //nolint:gosec // args are controlled
 	if err := cmd.Run(); err != nil {
 		return fmt.Errorf("ydotool type: %w", err)
 	}
@@ -82,7 +82,7 @@ func typeX11Direct(text string) error {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	cmd := exec.CommandContext(ctx, "xdotool", "type", "--delay", "0", "--", text)
+	cmd := exec.CommandContext(ctx, "xdotool", "type", "--delay", "0", "--", text) //nolint:gosec // args are controlled
 	if err := cmd.Run(); err != nil {
 		return fmt.Errorf("xdotool type: %w", err)
 	}
@@ -104,7 +104,7 @@ func typeWayland(text string) error {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	cmd := exec.CommandContext(ctx, "wl-copy", "--", text)
+	cmd := exec.CommandContext(ctx, "wl-copy", "--", text) //nolint:gosec // args are controlled
 	if err := cmd.Run(); err != nil {
 		return fmt.Errorf("wl-copy: %w", err)
 	}
@@ -115,7 +115,7 @@ func typeWayland(text string) error {
 
 	// Clear clipboard after paste (best-effort)
 	time.Sleep(100 * time.Millisecond)
-	exec.CommandContext(ctx, "wl-copy", "--clear").Run()
+	_ = exec.CommandContext(ctx, "wl-copy", "--clear").Run()
 
 	return nil
 }
@@ -136,7 +136,7 @@ func pasteX11(text string) error {
 
 	// Clear clipboard after paste (best-effort)
 	time.Sleep(100 * time.Millisecond)
-	atclip.WriteAll("")
+	_ = atclip.WriteAll("")
 
 	return nil
 }

--- a/internal/clipboard/clipboard_linux_test.go
+++ b/internal/clipboard/clipboard_linux_test.go
@@ -14,14 +14,18 @@ func TestIsWayland(t *testing.T) {
 
 func TestIsWaylandDetection(t *testing.T) {
 	orig := os.Getenv("WAYLAND_DISPLAY")
-	defer os.Setenv("WAYLAND_DISPLAY", orig)
+	defer func() { _ = os.Setenv("WAYLAND_DISPLAY", orig) }()
 
-	os.Setenv("WAYLAND_DISPLAY", "wayland-0")
+	if err := os.Setenv("WAYLAND_DISPLAY", "wayland-0"); err != nil {
+		t.Fatal(err)
+	}
 	if !isWayland() {
 		t.Error("expected isWayland()=true when WAYLAND_DISPLAY is set")
 	}
 
-	os.Unsetenv("WAYLAND_DISPLAY")
+	if err := os.Unsetenv("WAYLAND_DISPLAY"); err != nil {
+		t.Fatal(err)
+	}
 	if isWayland() {
 		t.Error("expected isWayland()=false when WAYLAND_DISPLAY is unset")
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -114,7 +114,7 @@ func DefaultDataDir() string {
 // corrupt the existing config.
 func Save(path string, cfg *Config) error {
 	dir := filepath.Dir(path)
-	if err := os.MkdirAll(dir, 0o755); err != nil {
+	if err := os.MkdirAll(dir, 0o750); err != nil {
 		return err
 	}
 	tmp, err := os.CreateTemp(dir, ".palaver-config-*.tmp")
@@ -124,20 +124,20 @@ func Save(path string, cfg *Config) error {
 	tmpPath := tmp.Name()
 
 	if err := toml.NewEncoder(tmp).Encode(cfg); err != nil {
-		tmp.Close()
-		os.Remove(tmpPath)
+		_ = tmp.Close()
+		_ = os.Remove(tmpPath)
 		return err
 	}
 	if err := tmp.Sync(); err != nil {
-		tmp.Close()
-		os.Remove(tmpPath)
+		_ = tmp.Close()
+		_ = os.Remove(tmpPath)
 		return err
 	}
 	if err := tmp.Close(); err != nil {
-		os.Remove(tmpPath)
+		_ = os.Remove(tmpPath)
 		return err
 	}
-	return os.Rename(tmpPath, path)
+	return os.Rename(tmpPath, path) //nolint:gosec // atomic rename within user config dir
 }
 
 // Load reads the TOML config from path. If the file does not exist,

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -75,7 +75,7 @@ command = "whisper-cpp -f {input}"
 [paste]
 delay_ms = 100
 `
-	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
 		t.Fatal(err)
 	}
 
@@ -172,7 +172,7 @@ func TestLoadPartialOverride(t *testing.T) {
 [hotkey]
 key = "KEY_F5"
 `
-	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
 		t.Fatal(err)
 	}
 

--- a/internal/hotkey/hotkey_linux.go
+++ b/internal/hotkey/hotkey_linux.go
@@ -162,7 +162,7 @@ func FindKeyboard(devicePath string) (*evdev.InputDevice, error) {
 		if isKeyboard(dev) {
 			return dev, nil
 		}
-		dev.Close()
+		_ = dev.Close()
 	}
 
 	return nil, fmt.Errorf("no keyboard device found in /dev/input/event*")
@@ -265,7 +265,7 @@ func (l *linuxListener) Stop() {
 	defer l.mu.Unlock()
 	if !l.closed {
 		l.closed = true
-		l.dev.Close()
+		_ = l.dev.Close()
 	}
 }
 

--- a/internal/recorder/recorder.go
+++ b/internal/recorder/recorder.go
@@ -77,7 +77,7 @@ func (r *Recorder) Start() error {
 	}
 
 	if err := stream.Start(); err != nil {
-		stream.Close()
+		_ = stream.Close()
 		return fmt.Errorf("start stream: %w", err)
 	}
 
@@ -159,8 +159,8 @@ func (r *Recorder) Stop() ([]byte, bool, error) {
 	}
 
 	if r.stream != nil {
-		r.stream.Stop()
-		r.stream.Close()
+		_ = r.stream.Stop()
+		_ = r.stream.Close()
 		r.stream = nil
 	}
 
@@ -274,7 +274,7 @@ func Resample(samples []int16, inputRate, outputRate float64) ([]int16, error) {
 // by averaging left and right channels.
 func DownmixStereoToMono(stereo []int16) []int16 {
 	mono := make([]int16, len(stereo)/2)
-	for i := 0; i < len(stereo); i += 2 {
+	for i := 0; i+1 < len(stereo); i += 2 {
 		mono[i/2] = int16((int32(stereo[i]) + int32(stereo[i+1])) / 2)
 	}
 	return mono

--- a/internal/server/platform_linux.go
+++ b/internal/server/platform_linux.go
@@ -22,10 +22,6 @@ func serverBinaryName() string {
 	return "parakeet"
 }
 
-func serverBinaryPath() string {
-	return ""
-}
-
 func resolveServerBinary(dataDir string) string {
 	return filepath.Join(dataDir, "parakeet")
 }
@@ -85,7 +81,7 @@ func setupServer(binaryPath, modelsDir, onnxDir string, logger *log.Logger, prog
 			os.Remove(binaryPath)
 			return fmt.Errorf("downloaded binary is invalid: %w", err)
 		}
-		if err := os.Chmod(binaryPath, 0o755); err != nil {
+		if err := os.Chmod(binaryPath, 0o755); err != nil { //nolint:gosec // binary must be executable
 			return fmt.Errorf("chmod parakeet binary: %w", err)
 		}
 	}
@@ -142,7 +138,7 @@ func verifyBinary(path string) error {
 	if err != nil {
 		return err
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	magic := make([]byte, 4)
 	if _, err := io.ReadFull(f, magic); err != nil {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -81,7 +81,7 @@ func (s *Server) Start(ctx context.Context) error {
 
 	s.Logger.Printf("starting %s on port %d", serverBinaryName(), s.Port)
 
-	cmd := exec.CommandContext(ctx, s.BinaryPath, serverArgs(s.Port, s.ModelsDir)...)
+	cmd := exec.CommandContext(ctx, s.BinaryPath, serverArgs(s.Port, s.ModelsDir)...) //nolint:gosec // binary path from managed install
 	cmd.Stdout = s.Logger.Writer()
 	cmd.Stderr = s.Logger.Writer()
 
@@ -105,9 +105,9 @@ func (s *Server) Start(ctx context.Context) error {
 			return ctx.Err()
 		case <-time.After(500 * time.Millisecond):
 		}
-		resp, err := http.Get(healthURL)
+		resp, err := http.Get(healthURL) //nolint:gosec // URL from hardcoded localhost
 		if err == nil {
-			resp.Body.Close()
+			_ = resp.Body.Close()
 			if resp.StatusCode == http.StatusOK {
 				s.Logger.Printf("%s", serverReadyLog())
 				return nil
@@ -140,7 +140,7 @@ func (s *Server) Stop() error {
 	select {
 	case <-done:
 	case <-time.After(5 * time.Second):
-		s.cmd.Process.Kill()
+		_ = s.cmd.Process.Kill()
 		<-done
 	}
 

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -63,30 +63,30 @@ func TestIsInstalledTrueWhenPresent(t *testing.T) {
 		// On macOS, BinaryPath is from PATH (whisper-server).
 		// Override it to a temp file so we can test IsInstalled.
 		srv.BinaryPath = filepath.Join(dir, "whisper-server")
-		if err := os.WriteFile(srv.BinaryPath, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		if err := os.WriteFile(srv.BinaryPath, []byte("#!/bin/sh\n"), 0o700); err != nil {
 			t.Fatal(err)
 		}
-		if err := os.MkdirAll(srv.ModelsDir, 0o755); err != nil {
+		if err := os.MkdirAll(srv.ModelsDir, 0o700); err != nil {
 			t.Fatal(err)
 		}
-		if err := os.WriteFile(filepath.Join(srv.ModelsDir, "ggml-base.en.bin"), []byte("fake"), 0o644); err != nil {
+		if err := os.WriteFile(filepath.Join(srv.ModelsDir, "ggml-base.en.bin"), []byte("fake"), 0o600); err != nil {
 			t.Fatal(err)
 		}
 	} else {
 		// Linux: binary + encoder model + onnxruntime
-		if err := os.WriteFile(srv.BinaryPath, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		if err := os.WriteFile(srv.BinaryPath, []byte("#!/bin/sh\n"), 0o700); err != nil {
 			t.Fatal(err)
 		}
-		if err := os.MkdirAll(srv.ModelsDir, 0o755); err != nil {
+		if err := os.MkdirAll(srv.ModelsDir, 0o700); err != nil {
 			t.Fatal(err)
 		}
-		if err := os.WriteFile(filepath.Join(srv.ModelsDir, "encoder-model.int8.onnx"), []byte("fake"), 0o644); err != nil {
+		if err := os.WriteFile(filepath.Join(srv.ModelsDir, "encoder-model.int8.onnx"), []byte("fake"), 0o600); err != nil {
 			t.Fatal(err)
 		}
-		if err := os.MkdirAll(srv.OnnxDir, 0o755); err != nil {
+		if err := os.MkdirAll(srv.OnnxDir, 0o700); err != nil {
 			t.Fatal(err)
 		}
-		if err := os.WriteFile(filepath.Join(srv.OnnxDir, "libonnxruntime"+libExtension()), []byte("fake"), 0o644); err != nil {
+		if err := os.WriteFile(filepath.Join(srv.OnnxDir, "libonnxruntime"+libExtension()), []byte("fake"), 0o600); err != nil {
 			t.Fatal(err)
 		}
 	}

--- a/internal/transcriber/command.go
+++ b/internal/transcriber/command.go
@@ -42,10 +42,10 @@ func (c *Command) Transcribe(ctx context.Context, wavData []byte) (string, error
 	defer os.Remove(tmpPath)
 
 	if _, err := tmpFile.Write(wavData); err != nil {
-		tmpFile.Close()
+		_ = tmpFile.Close()
 		return "", fmt.Errorf("write temp file: %w", err)
 	}
-	tmpFile.Close()
+	_ = tmpFile.Close()
 
 	cmdStr := strings.ReplaceAll(c.command, "{input}", tmpPath)
 	if cmdStr == "" {

--- a/internal/transcriber/openai.go
+++ b/internal/transcriber/openai.go
@@ -29,7 +29,7 @@ func NewOpenAI(baseURL, model string, timeoutSec int, tlsSkipVerify bool, logger
 	client := &http.Client{}
 	if tlsSkipVerify {
 		client.Transport = &http.Transport{
-			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, //nolint:gosec // user-configured opt-in for self-signed certs
 		}
 	}
 	return &OpenAI{
@@ -56,11 +56,11 @@ func (o *OpenAI) Ping(ctx context.Context) error {
 		return fmt.Errorf("build ping request: %w", err)
 	}
 
-	resp, err := o.client.Do(req)
+	resp, err := o.client.Do(req) //nolint:gosec // URL from user config
 	if err != nil {
 		return fmt.Errorf("ping: %w", err)
 	}
-	resp.Body.Close()
+	_ = resp.Body.Close()
 	return nil
 }
 
@@ -74,7 +74,7 @@ func (o *OpenAI) ListModels(ctx context.Context) ([]string, error) {
 		return nil, fmt.Errorf("build models request: %w", err)
 	}
 
-	resp, err := o.client.Do(req)
+	resp, err := o.client.Do(req) //nolint:gosec // URL from user config
 	if err != nil {
 		return nil, fmt.Errorf("list models: %w", err)
 	}
@@ -139,7 +139,7 @@ func (o *OpenAI) Transcribe(ctx context.Context, wavData []byte) (string, error)
 	req.Header.Set("Content-Type", writer.FormDataContentType())
 
 	start := time.Now()
-	resp, err := o.client.Do(req)
+	resp, err := o.client.Do(req) //nolint:gosec // URL from user config
 	if err != nil {
 		return "", fmt.Errorf("send request: %w", err)
 	}

--- a/internal/transcriber/openai_test.go
+++ b/internal/transcriber/openai_test.go
@@ -21,7 +21,7 @@ func TestOpenAITranscribe(t *testing.T) {
 		}
 		if r.Method != http.MethodPost {
 			t.Errorf("unexpected method: %s", r.Method)
-			http.Error(w, "method not allowed", 405)
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
 			return
 		}
 
@@ -41,11 +41,11 @@ func TestOpenAITranscribe(t *testing.T) {
 			http.Error(w, "bad request", 400)
 			return
 		}
-		defer file.Close()
+		defer func() { _ = file.Close() }()
 		receivedFileData, _ = io.ReadAll(file)
 
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte("  Hello world  "))
+		_, _ = w.Write([]byte("  Hello world  "))
 	}))
 	defer server.Close()
 

--- a/internal/tui/logwriter.go
+++ b/internal/tui/logwriter.go
@@ -39,10 +39,7 @@ func parseLine(line string) DebugEntry {
 	}
 
 	// Strip "[DEBUG] " prefix
-	msg := line
-	if strings.HasPrefix(msg, "[DEBUG] ") {
-		msg = msg[8:]
-	}
+	msg := strings.TrimPrefix(line, "[DEBUG] ")
 
 	// Extract timestamp (HH:MM:SS.micros or HH:MM:SS)
 	if len(msg) >= 8 && msg[2] == ':' && msg[5] == ':' {

--- a/internal/tui/tui_test.go
+++ b/internal/tui/tui_test.go
@@ -28,19 +28,6 @@ func (m *mockLevelSampler) AudioLevel() float64 {
 	return m.level
 }
 
-type mockMicChecker struct {
-	available bool
-	name      string
-}
-
-func (m *mockMicChecker) MicAvailable() bool {
-	return m.available
-}
-
-func (m *mockMicChecker) MicName() string {
-	return m.name
-}
-
 func newTestModel() Model {
 	cfg := config.Default()
 	return NewModel(cfg, &mockTranscriber{result: "test text"}, nil, nil, nil, log.New(io.Discard, "", 0), false)


### PR DESCRIPTION
## Summary
- Fix 39 **errcheck** findings: add explicit `_ =` discards for deferred `Close()`, `Remove()`, and other best-effort cleanup calls
- Fix 24 **gosec** findings: `nolint` annotations with rationale for intentional patterns (user-config file paths, hardcoded URLs, subprocess args, opt-in TLS skip), tighten directory permissions from 0755 to 0750, add bounds check in `DownmixStereoToMono`
- Fix 2 **staticcheck** findings: replace `HasPrefix`+slice with `TrimPrefix`, use `http.StatusMethodNotAllowed` constant
- Fix 4 **unused** findings: remove dead `serverBinaryPath()` on Linux, remove unused `mockMicChecker` test type
- Remove `only-new-issues` from CI since all findings are now resolved

## Test plan
- [x] `go vet ./...` passes
- [x] `gofmt -l .` reports no unformatted files
- [x] `go test ./...` — all tests pass
- [x] CI lint job passes without `only-new-issues`

🤖 Generated with [Claude Code](https://claude.com/claude-code)