### PR TITLE
Skip paste when transcription returns [BLANK_AUDIO]

### DIFF
--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -220,7 +220,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case TranscriptionResultMsg:
 		text := msg.Text
 		m.Logger.Printf("transcription result: %q", text)
-		if text == "" {
+		if text == "" || text == "[BLANK_AUDIO]" {
 			m.State = StateIdle
 			m.Logger.Printf("empty transcription, skipping paste")
 			return m, nil

--- a/internal/tui/tui_test.go
+++ b/internal/tui/tui_test.go
@@ -92,6 +92,19 @@ func TestTranscriptionResultTransition(t *testing.T) {
 	}
 }
 
+func TestBlankAudioTranscriptionSkipsPaste(t *testing.T) {
+	m := newTestModel()
+	m.State = StateTranscribing
+	updated, cmd := m.Update(TranscriptionResultMsg{Text: "[BLANK_AUDIO]"})
+	model := updated.(Model)
+	if model.State != StateIdle {
+		t.Errorf("expected StateIdle, got %d", model.State)
+	}
+	if cmd != nil {
+		t.Error("expected no command for blank audio")
+	}
+}
+
 func TestTranscriptionErrorTransition(t *testing.T) {
 	m := newTestModel()
 	m.State = StateTranscribing


### PR DESCRIPTION
## Summary
- Skip pasting when whisper-cpp returns `[BLANK_AUDIO]` (e.g. when no audio is recorded)
- Reuses existing empty-transcription skip logic in the TUI model

Closes #7

## Test plan
- [x] Added `TestBlankAudioTranscriptionSkipsPaste` — verifies state returns to Idle with no paste command
- [x] `go test ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)