### PR TITLE
Fix govulncheck vulnerabilities and update CodeQL to v4

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -48,12 +48,12 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y portaudio19-dev
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@v4
         with:
           languages: go
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v3
+        uses: github/codeql-action/autobuild@v4
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@v4

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/Danondso/palaver
 
-go 1.25.7
+go 1.25.8
 
 require (
 	github.com/BurntSushi/toml v1.6.0


### PR DESCRIPTION
## Summary
- Bump Go from 1.25.7 to 1.25.8 to fix GO-2026-4602 (`os.FileInfo` root escape) and GO-2026-4601 (`net/url` IPv6 host literal parsing)
- Update `github/codeql-action` from v3 to v4 ahead of the December 2026 deprecation

Closes #14

## Test plan
- [x] Verify `govulncheck ./...` passes with no symbol-level findings
- [x] Verify CodeQL job completes successfully with v4 actions

🤖 Generated with [Claude Code](https://claude.com/claude-code)