### PR TITLE
Bump Go to 1.26.3 for govulncheck

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/Danondso/palaver
 
-go 1.25.8
+go 1.26.3
 
 require (
 	github.com/BurntSushi/toml v1.6.0


### PR DESCRIPTION
## Summary

- Raises the `go` directive in `go.mod` from 1.25.8 to 1.26.3 so CI `govulncheck` uses a toolchain that includes patched standard-library fixes (TLS, `crypto/x509`, `net/http`, `archive/tar`, etc.).
- Workflows already use `go-version-file: go.mod`, so lint, test, build, security, and release jobs pick up the new version automatically.

## Test plan

- [x] Confirm Security workflow `govulncheck` passes on this PR.
- [x] `go test ./...` locally with Go 1.26.3 (or rely on CI).

Made with [Cursor](https://cursor.com)