### PR TITLE
Bump Go to 1.26.4 and deps to clear govulncheck findings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,9 +14,9 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
 
@@ -49,9 +49,9 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
 
@@ -80,9 +80,9 @@ jobs:
             goarch: arm64
             runner: macos-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
     outputs:
       new_tag: ${{ steps.tag.outputs.new_tag }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -31,9 +31,9 @@ jobs:
     needs: tag
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
 
@@ -50,7 +50,7 @@ jobs:
           tar czf palaver_${{ needs.tag.outputs.new_tag }}_linux_amd64.tar.gz \
             palaver README.md LICENSE install.sh uninstall.sh
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: palaver-linux-amd64
           path: palaver_*.tar.gz
@@ -60,9 +60,9 @@ jobs:
     needs: tag
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
 
@@ -81,7 +81,7 @@ jobs:
           tar czf palaver_${{ needs.tag.outputs.new_tag }}_darwin_arm64.tar.gz \
             palaver README.md LICENSE install.sh uninstall.sh
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: palaver-darwin-arm64
           path: palaver_*.tar.gz
@@ -91,7 +91,7 @@ jobs:
     needs: [tag, build-linux, build-macos-arm64]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           merge-multiple: true
 

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -16,9 +16,9 @@ jobs:
     name: govulncheck
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
 
@@ -38,9 +38,9 @@ jobs:
       contents: read
       security-events: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/Danondso/palaver
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/BurntSushi/toml v1.6.0
@@ -36,7 +36,7 @@ require (
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/tphakala/simd v1.0.12 // indirect
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
-	golang.org/x/sys v0.38.0 // indirect
+	golang.org/x/sys v0.44.0 // indirect
 	golang.org/x/text v0.23.0 // indirect
 	gonum.org/v1/gonum v0.16.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -71,8 +71,8 @@ golang.org/x/exp v0.0.0-20220909182711-5c715a9e8561 h1:MDc5xs78ZrZr3HMQugiXOAkSZ
 golang.org/x/exp v0.0.0-20220909182711-5c715a9e8561/go.mod h1:cyybsKvd6eL0RnXn6p/Grxp8F5bW7iYuBgsNCOHpMYE=
 golang.org/x/sys v0.0.0-20210809222454-d867a43fc93e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.38.0 h1:3yZWxaJjBmCWXqhN1qh02AkOnCQ1poK6oF+a7xWL6Gc=
-golang.org/x/sys v0.38.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=
+golang.org/x/sys v0.44.0 h1:ildZl3J4uzeKP07r2F++Op7E9B29JRUy+a27EibtBTQ=
+golang.org/x/sys v0.44.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 golang.org/x/text v0.23.0 h1:D71I7dUrlY+VX0gQShAThNGHFxZ13dGLBHQLVl1mJlY=
 golang.org/x/text v0.23.0/go.mod h1:/BLNzu4aZCJ1+kcD0DNRotWKage4q2rGVAg4o22unh4=
 gonum.org/v1/gonum v0.16.0 h1:5+ul4Swaf3ESvrOnidPp4GZbzf0mxVQpDCYUQE7OJfk=


### PR DESCRIPTION
## Summary

Resolves the failing scheduled **Security** run (`govulncheck` job, [run 27130691001](https://github.com/Danondso/palaver/actions/runs/27130691001)). All findings were Go standard-library advisories fixed in go1.26.4, plus one dependency advisory.

- Bump `go` directive `1.26.3` → `1.26.4` — clears [GO-2026-5039](https://pkg.go.dev/vuln/GO-2026-5039) (`net/textproto`), [GO-2026-5037](https://pkg.go.dev/vuln/GO-2026-5037) (`crypto/x509`), and [GO-2026-5038](https://pkg.go.dev/vuln/GO-2026-5038) (`mime`). Workflows use `go-version-file: go.mod`, so CI scans with the patched toolchain.
- Bump `golang.org/x/sys` `v0.38.0` → `v0.44.0` — clears [GO-2026-5024](https://pkg.go.dev/vuln/GO-2026-5024).
- Bump Node 20 GitHub Actions across all workflows (`checkout@v6`, `setup-go@v6`, `upload-artifact@v7`, `download-artifact@v8`) to silence the deprecation warnings before the June 16 Node 24 cutover.

## Test plan

- [x] `go build ./...`
- [x] `go test ./...` (all packages pass)
- [x] `govulncheck ./...` → **No vulnerabilities found**

## Follow-up (out of scope)

- `golangci/golangci-lint-action@v7` is also a Node 20 action; v7→v9 has breaking input changes, so it's intentionally left for a dedicated PR.

Made with [Cursor](https://cursor.com)