### PR TITLE
ci: bump golangci/golangci-lint-action v7 -> v9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
         run: go vet ./...
 
       - name: Run golangci-lint
-        uses: golangci/golangci-lint-action@v7
+        uses: golangci/golangci-lint-action@v9
         with:
           version: v2.10.1
           only-new-issues: true


### PR DESCRIPTION
## Summary

Dedicated follow-up to the recent security-hardening work. That PR intentionally left `golangci/golangci-lint-action` at `v7` because v7 still runs on the deprecated Node 20 runtime, and we didn't want to risk turning CI red as part of a security patch.

This PR bumps the action `v7` -> `v9` (`v9.2.1` is current latest major), which moves it onto the **Node 24** runtime (introduced in `v9.0.0`).

## Why this is low-risk

The existing inputs are preserved unchanged:

- `version: v2.10.1` — still satisfies the action's `golangci-lint >= v2.1.0` requirement; v7, v8, and v9 all target golangci-lint **v2**.
- `only-new-issues: true` — this input is unchanged across v7..v9.

Reviewing the breaking changes between v7 and v9:

- **v8.0.0** — uses absolute paths by default *when using the `working-directory` option*. This workflow does not set `working-directory`, so no impact.
- **v9.0.0** — Node 20 -> Node 24 runtime (the whole point of this PR), plus new opt-in `install-only` and module-plugin-system options we don't use.

Verified against `action.yml` at `v9.2.1`: both `version` and `only-new-issues` inputs still exist.

## Test plan

- [ ] CI `Lint` job runs golangci-lint successfully on this PR
- [ ] No new lint findings surfaced (`only-new-issues` behavior preserved)

Made with [Cursor](https://cursor.com)